### PR TITLE
Fix error strings

### DIFF
--- a/controllers/api/import.go
+++ b/controllers/api/import.go
@@ -24,7 +24,7 @@ type cloneRequest struct {
 
 func (cr *cloneRequest) validate() error {
 	if cr.URL == "" {
-		return errors.New("No URL Specified")
+		return errors.New("no url specified")
 	}
 	return nil
 }

--- a/controllers/api/user.go
+++ b/controllers/api/user.go
@@ -15,17 +15,17 @@ import (
 )
 
 // ErrUsernameTaken is thrown when a user attempts to register a username that is taken.
-var ErrUsernameTaken = errors.New("Username already taken")
+var ErrUsernameTaken = errors.New("username already taken")
 
 // ErrEmptyUsername is thrown when a user attempts to register a username that is taken.
-var ErrEmptyUsername = errors.New("No username provided")
+var ErrEmptyUsername = errors.New("no username provided")
 
 // ErrEmptyRole is throws when no role is provided when creating or modifying a user.
-var ErrEmptyRole = errors.New("No role specified")
+var ErrEmptyRole = errors.New("no role specified")
 
 // ErrInsufficientPermission is thrown when a user attempts to change an
 // attribute (such as the role) for which they don't have permission.
-var ErrInsufficientPermission = errors.New("Permission denied")
+var ErrInsufficientPermission = errors.New("permission denied")
 
 // userRequest is the payload which represents the creation of a new user.
 type userRequest struct {


### PR DESCRIPTION
PR muy chico, arregla el uso de mayusculas en el levantamiento de errores para cumplir con el static check:

![image](https://github.com/gophish/gophish/assets/78695941/6b10b6f1-c530-4367-b08c-299c574edcd4)
